### PR TITLE
Split CI workflow into test and build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,30 +5,49 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  test:
+    name: Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: 1. Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: 2. Set up Python 3.10
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
-      - name: Install package and test deps
+      - name: 3. Install package and test deps
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest build
+          pip install pytest
 
-      - name: Run tests
+      - name: 4. Run tests
         run: pytest --maxfail=1 --disable-warnings -q
 
-      - name: Build package
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: 1. Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 2. Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: 3. Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: 4. Build package
         run: python -m build
 
-      - name: Upload package artifact
+      - name: 5. Upload package artifact
         uses: actions/upload-artifact@v4
         with:
           name: math_utils-dist


### PR DESCRIPTION
Refactored the CI workflow to separate testing and building into distinct jobs. The 'test' job runs tests, and the 'build' job builds the package and uploads the artifact, depending on successful test completion. This improves workflow clarity and ensures builds only occur after passing tests.